### PR TITLE
fix(refresh): preserve repository state and refresh filters

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -20,43 +20,39 @@ export function getSettings(): ExtensionSettings {
   const config = vscode.workspace.getConfiguration("gitea-vs-extension");
   const legacyConfig = vscode.workspace.getConfiguration("bircni.gitea-vs-extension");
   return {
-    baseUrl: (config.get<string>("baseUrl") ?? legacyConfig.get<string>("baseUrl") ?? "").trim(),
-    tlsInsecureSkipVerify:
-      config.get<boolean>("tls.insecureSkipVerify") ??
-      legacyConfig.get<boolean>("tls.insecureSkipVerify") ??
-      false,
-    discoveryMode:
-      config.get<DiscoveryMode>("discovery.mode") ??
-      legacyConfig.get<DiscoveryMode>("discovery.mode") ??
-      "workspace",
-    runningRefreshSeconds:
-      config.get<number>("refresh.runningIntervalSeconds") ??
-      legacyConfig.get<number>("refresh.runningIntervalSeconds") ??
-      15,
-    idleRefreshSeconds:
-      config.get<number>("refresh.idleIntervalSeconds") ??
-      legacyConfig.get<number>("refresh.idleIntervalSeconds") ??
-      60,
-    maxRunsPerRepo:
-      config.get<number>("maxRunsPerRepo") ?? legacyConfig.get<number>("maxRunsPerRepo") ?? 20,
-    maxJobsPerRun:
-      config.get<number>("maxJobsPerRun") ?? legacyConfig.get<number>("maxJobsPerRun") ?? 50,
-    debugLogging:
-      config.get<boolean>("logging.debug") ?? legacyConfig.get<boolean>("logging.debug") ?? false,
-    reviewCommentsEnabled:
-      config.get<boolean>("reviewComments.enabled") ??
-      legacyConfig.get<boolean>("reviewComments.enabled") ??
-      true,
-    jobLogsSaveToRepo:
-      config.get<boolean>("jobLogs.saveToRepo") ??
-      legacyConfig.get<boolean>("jobLogs.saveToRepo") ??
-      true,
-    artifactsDownloadPath: (
-      config.get<string>("artifacts.downloadPath") ??
-      legacyConfig.get<string>("artifacts.downloadPath") ??
-      ".tmp/gitea-artifacts/"
+    baseUrl: getSetting(config, legacyConfig, "baseUrl", "").trim(),
+    tlsInsecureSkipVerify: getSetting(config, legacyConfig, "tls.insecureSkipVerify", false),
+    discoveryMode: getSetting<DiscoveryMode>(config, legacyConfig, "discovery.mode", "workspace"),
+    runningRefreshSeconds: getSetting(config, legacyConfig, "refresh.runningIntervalSeconds", 15),
+    idleRefreshSeconds: getSetting(config, legacyConfig, "refresh.idleIntervalSeconds", 60),
+    maxRunsPerRepo: getSetting(config, legacyConfig, "maxRunsPerRepo", 20),
+    maxJobsPerRun: getSetting(config, legacyConfig, "maxJobsPerRun", 50),
+    debugLogging: getSetting(config, legacyConfig, "logging.debug", false),
+    reviewCommentsEnabled: getSetting(config, legacyConfig, "reviewComments.enabled", true),
+    jobLogsSaveToRepo: getSetting(config, legacyConfig, "jobLogs.saveToRepo", true),
+    artifactsDownloadPath: getSetting(
+      config,
+      legacyConfig,
+      "artifacts.downloadPath",
+      ".tmp/gitea-artifacts/",
     ).trim(),
   };
+}
+
+/**
+ * Prefer an explicitly configured modern setting. `get()` includes contributed defaults, so it
+ * cannot distinguish an unset modern value from its default when reading legacy configuration.
+ */
+function getSetting<T>(
+  config: vscode.WorkspaceConfiguration,
+  legacyConfig: vscode.WorkspaceConfiguration,
+  key: string,
+  fallback: T,
+): T {
+  const inspected = config.inspect<T>(key);
+  const explicitModernValue =
+    inspected?.workspaceFolderValue ?? inspected?.workspaceValue ?? inspected?.globalValue;
+  return explicitModernValue ?? legacyConfig.get<T>(key) ?? fallback;
 }
 
 /**

--- a/src/controllers/commands.ts
+++ b/src/controllers/commands.ts
@@ -219,6 +219,8 @@ export class CommandsController {
       this.store.setBranchFilter({ repo, mode: "specificBranch", branchName: id });
     }
 
+    const settings = getSettings();
+    await this.refreshController.refreshRepo(repo, settings.maxRunsPerRepo);
     this.treeProvider.refresh();
     this.refreshViews?.();
   }

--- a/src/controllers/refreshController.ts
+++ b/src/controllers/refreshController.ts
@@ -66,14 +66,23 @@ export class RefreshController {
     try {
       const settings = getSettings();
       let repos: RepoRef[] = [];
+      let discoverySucceeded = true;
 
       try {
         repos = await this.discovery.discoverRepos(settings.discoveryMode, settings.baseUrl);
       } catch (error) {
+        discoverySucceeded = false;
         this.logger.warn(`Repository discovery failed: ${formatRefreshError(error)}`);
       }
 
-      this.store.setRepos(repos);
+      // Keep previously discovered repositories visible when discovery fails transiently. They can
+      // still be refreshed individually, while replacing the store with an empty list would make
+      // a network outage look like the user has no repositories.
+      if (discoverySucceeded) {
+        this.store.setRepos(repos);
+      } else {
+        repos = this.store.getRepos();
+      }
 
       try {
         const discoveredRepoKeys = new Set(repos.map((repo) => repoKey(repo)));

--- a/src/gitea/api.ts
+++ b/src/gitea/api.ts
@@ -352,7 +352,17 @@ export class GiteaApi {
     if (!path) {
       throw new EndpointError("Repository listing endpoint not available");
     }
-    const response = await this.client.getJson<unknown[]>(path);
+    const pageSize = 50;
+    const response: unknown[] = [];
+    for (let page = 1; ; page += 1) {
+      const items = await this.client.getJson<unknown[]>(
+        withQuery(path, { page: String(page), limit: String(pageSize) }),
+      );
+      response.push(...items);
+      if (items.length < pageSize) {
+        break;
+      }
+    }
     const host = getHost(this.baseUrlProvider());
     if (!host) {
       return [];

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -1,5 +1,6 @@
 export const workspace = {
   workspaceFolders: [] as { uri: { fsPath: string } }[] | undefined,
+  getConfiguration: vi.fn(),
 };
 
 export const window = {

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -140,6 +140,22 @@ describe("GiteaApi core endpoints", () => {
     );
   });
 
+  test("loads every page of accessible repositories", async () => {
+    const firstPage = Array.from({ length: 50 }, (_, index) => ({
+      owner: { login: "owner" },
+      name: `repo-${index}`,
+    }));
+    client.getJson
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([{ owner: { login: "owner" }, name: "repo-50" }]);
+
+    const repos = await api.listAccessibleRepos();
+
+    expect(client.getJson).toHaveBeenNthCalledWith(1, "/api/v1/user/repos?page=1&limit=50");
+    expect(client.getJson).toHaveBeenNthCalledWith(2, "/api/v1/user/repos?page=2&limit=50");
+    expect(repos).toHaveLength(51);
+  });
+
   test("lists jobs with run id", async () => {
     client.getJson.mockResolvedValueOnce({ jobs: [] });
 

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -6,6 +6,10 @@ import { CommandsController } from "../controllers/commands";
 import type { RepoRef } from "../gitea/models";
 import type { Mock } from "vitest";
 
+vi.mock("../config/settings", () => ({
+  getSettings: vi.fn(() => ({ maxRunsPerRepo: 20 })),
+}));
+
 const mockRepo: RepoRef = { host: "gitea.example", owner: "o", name: "n" };
 
 function createMockContext(): vscode.ExtensionContext {
@@ -114,5 +118,35 @@ describe("CommandsController", () => {
     expect(registeredIds).toContain("gitea-vs-extension.setToken");
     expect(registeredIds).toContain("gitea-vs-extension.refreshSecrets");
     expect(registeredIds).toContain("gitea-vs-extension.downloadArtifact");
+  });
+
+  it("refreshes the repository immediately after changing its branch filter", async () => {
+    const refreshRepo = vi.fn().mockResolvedValue();
+    const setBranchFilter = vi.fn();
+    const store = {
+      getEntry: () => ({ runs: [] }),
+      getBranchContext: () => ({ status: "resolved", branchName: "main" }),
+      setBranchFilter,
+    };
+    const treeProvider = { refresh: vi.fn() };
+    const controller = new CommandsController(
+      createMockContext(),
+      {} as never,
+      { refreshAll: vi.fn(), refreshRepo } as never,
+      store as never,
+      treeProvider as never,
+      { getCurrentRepo: () => mockRepo, setTokenStatus: vi.fn() } as never,
+    );
+    controller.register();
+    (vscode.window.showQuickPick as Mock).mockResolvedValueOnce({ id: "currentBranch" });
+    const call = (vscode.commands.registerCommand as Mock).mock.calls.find(
+      (c: [string]) => c[0] === "gitea-vs-extension.switchBranchFilter",
+    );
+
+    await call?.[1]();
+
+    expect(setBranchFilter).toHaveBeenCalledWith({ repo: mockRepo, mode: "currentBranch" });
+    expect(refreshRepo).toHaveBeenCalledWith(mockRepo, 20);
+    expect(treeProvider.refresh).toHaveBeenCalled();
   });
 });

--- a/src/test/refreshController.test.ts
+++ b/src/test/refreshController.test.ts
@@ -158,15 +158,16 @@ describe("RefreshController", () => {
     controller.dispose();
   });
 
-  it("refreshAll() when discovery throws still sets repos and continues", async () => {
+  it("refreshAll() preserves previously discovered repos when discovery throws", async () => {
     const store = createMockStore();
-    store.getRepos.mockReturnValue([]);
+    store.getRepos.mockReturnValue([mockRepo]);
     const logger = { warn: vi.fn(), debug: vi.fn() };
     const discovery = createMockDiscovery();
     discovery.discoverRepos.mockRejectedValue(new Error("Discovery failed"));
+    const api = createMockApi();
 
     const controller = new RefreshController(
-      createMockApi() as never,
+      api as never,
       store as never,
       discovery as never,
       logger as never,
@@ -179,7 +180,8 @@ describe("RefreshController", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("Repository discovery failed"),
     );
-    expect(store.setRepos).toHaveBeenCalledWith([]);
+    expect(store.setRepos).not.toHaveBeenCalled();
+    expect(api.listRuns).toHaveBeenCalledWith(mockRepo, 10);
     controller.dispose();
   });
 

--- a/src/test/settings.test.ts
+++ b/src/test/settings.test.ts
@@ -1,0 +1,52 @@
+import * as vscode from "vscode";
+import { getSettings } from "../config/settings";
+import type { Mock } from "vitest";
+
+function configuration(
+  values: Record<string, unknown>,
+  explicitValues: Record<string, unknown> = {},
+): vscode.WorkspaceConfiguration {
+  return {
+    get: vi.fn((key: string) => values[key]),
+    inspect: vi.fn((key: string) =>
+      key in explicitValues
+        ? { defaultValue: values[key], globalValue: explicitValues[key] }
+        : undefined,
+    ),
+  } as unknown as vscode.WorkspaceConfiguration;
+}
+
+describe("getSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses legacy settings when modern settings only provide contributed defaults", () => {
+    const modern = configuration({ baseUrl: "", maxRunsPerRepo: 20 });
+    const legacy = configuration({ baseUrl: "https://legacy.example", maxRunsPerRepo: 99 });
+    (vscode.workspace.getConfiguration as Mock).mockImplementation((section: string) =>
+      section === "gitea-vs-extension" ? modern : legacy,
+    );
+
+    expect(getSettings()).toMatchObject({
+      baseUrl: "https://legacy.example",
+      maxRunsPerRepo: 99,
+    });
+  });
+
+  it("prefers an explicitly configured modern setting over a legacy one", () => {
+    const modern = configuration(
+      { baseUrl: "", maxRunsPerRepo: 20 },
+      { baseUrl: "https://modern.example", maxRunsPerRepo: 25 },
+    );
+    const legacy = configuration({ baseUrl: "https://legacy.example", maxRunsPerRepo: 99 });
+    (vscode.workspace.getConfiguration as Mock).mockImplementation((section: string) =>
+      section === "gitea-vs-extension" ? modern : legacy,
+    );
+
+    expect(getSettings()).toMatchObject({
+      baseUrl: "https://modern.example",
+      maxRunsPerRepo: 25,
+    });
+  });
+});


### PR DESCRIPTION
Fix refresh reliability and configuration compatibility.

- Reload branch-filtered runs immediately after changing the filter.
- Preserve discovered repositories during transient discovery failures.
- Paginate accessible-repository discovery and honor legacy settings unless modern values are explicitly configured.

The previous behavior could show stale or empty branch results, clear the tree during an outage, omit repositories after the first API page, and ignore legacy settings.

Validation: `npm run validate`.